### PR TITLE
Allow cancelling print job instead of issuing M112

### DIFF
--- a/octoprint_emergencystopsimplified/__init__.py
+++ b/octoprint_emergencystopsimplified/__init__.py
@@ -55,7 +55,7 @@ class Emergency_stop_simplifiedPlugin(octoprint.plugin.StartupPlugin,
     def _setup_button(self):
         if self.sensor_enabled():
             self._logger.info("Setting up button.")
-            self._logger.info("Using Board Mode")
+            self._logger.info("Using BCM Mode")
             GPIO.setmode(GPIO.BCM)
             self._logger.info("Emergency Stop button active on GPIO Pin [%s]" % self.pin)
             if self.switch is 0:
@@ -91,7 +91,7 @@ class Emergency_stop_simplifiedPlugin(octoprint.plugin.StartupPlugin,
 
         if not self.sensor_enabled():
             if event is Events.USER_LOGGED_IN:
-                self._plugin_manager.send_plugin_message(self._identifier, dict(type="info", autoClose=True, msg="Don' forget to configure this plugin."))
+                self._plugin_manager.send_plugin_message(self._identifier, dict(type="info", autoClose=True, msg="Don't forget to configure this plugin."))
             elif event is Events.PRINT_STARTED:
                 self._plugin_manager.send_plugin_message(self._identifier, dict(type="info", autoClose=True, msg="You may have forgotten to configure this plugin."))
 

--- a/octoprint_emergencystopsimplified/templates/emergencystopsimplified_settings.jinja2
+++ b/octoprint_emergencystopsimplified/templates/emergencystopsimplified_settings.jinja2
@@ -10,6 +10,7 @@
                    data-bind="value: settings.plugins.emergencystopsimplified.pin">
         </div>
     </div>
+
     <div class="control-group">
         <div class="marginBot">
             <b>Input terminal of the button (switch) needs to be connected to ground or 3.3 V</b>
@@ -33,6 +34,20 @@
         <div style="font-size: 11px">
             For more information click <a
                 href="https://github.com/Mechazawa/Emergency_stop_simplified">here</a>
+        </div>
+    </div>
+
+    <div class="control-group">
+        <div class="marginBot">
+            <b>{{ _('Which action to perform on button press') }}</b>
+        </div>
+        <label class="control-label">{{ _('Action to perform:') }}</label>
+        <div class="controls" data-toggle="tooltip"
+             title="{{ _('Gcode M112 shuts down the machine, turns off all the steppers and heaters, and if possible, turns off the power supply. A reset is required to return to operational mode.') }}">
+            <select class="select-mini" data-bind="value: settings.plugins.emergencystopsimplified.action">
+                <option value=0>{{ _('M112') }}</option>
+                <option value=1>{{ _('Cancel print') }}</option>
+            </select>
         </div>
     </div>
 </form>


### PR DESCRIPTION
This PR adds an option for cancelling print jobs instead of issuing the M112 code. This closes issue #1.